### PR TITLE
refactor: rename cx function to cn for clarity and fix build issues

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,9 +3,9 @@
 import clsx, { type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
-export function cx(...args: ClassValue[]) {
-  return twMerge(clsx(...args));
-}
+export const cn = (...inputs: ClassValue[]) => {
+  return twMerge(clsx(inputs));
+};
 
 // Tremor Raw focusInput [v0.0.1]
 


### PR DESCRIPTION
This pull request includes a change to the utility function in the `src/lib/utils.ts` file, which renames and modifies the function used for merging class names.

* [`src/lib/utils.ts`](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L6-R8): Renamed the `cx` function to `cn` and modified its implementation to use an arrow function and a different parameter name (`inputs` instead of `args`).